### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.txt linguist-language=AdBlock linguist-detectable
+*.adfl linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
Override Linguist config, see https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes