### PR TITLE
tools(FC): fix comment parser

### DIFF
--- a/tools/filter-combiner/filter_combiner/parser.py
+++ b/tools/filter-combiner/filter_combiner/parser.py
@@ -143,7 +143,7 @@ def parse_line(line, position='body'):
             return Header(match.group(1))
 
     # Comment syntax (rules starting with #)
-    if re.search('^!$|^![^#+]'                 # Standart comment
+    if re.search('^!$|^![^#]+|!#(\s.+)?$'      # Standart comment
                  '|^#$|^#[^#@$?%]|^##(\s|##)', # uBO special comment
                  stripped):
         match = RE_METADATA.match(line)


### PR DESCRIPTION
Related commit:
- https://github.com/realodix/AdBlockID/commit/741bfee85896c87e662289050a406d6b75b72871
- https://github.com/realodix/AdBlockID/commit/52519b96100f5a6c51b6c9985c84f28a4eab0fa2

Baris dibawah ini akan dianggap sebagai komentar oleh parser dan harus dihapus:
- Baris yang dimulai dengan simbol `!`
- Baris yang dimulai dengan simbol `#`

Baris dibawah ini akan dianggap sebagai filter oleh parser dan tidak boleh dihapus:
- Baris yang dimulai dengan simbol `!#` dan tanpa ada spasi setelah simbol `!#` 
  - `!#if`, `!#endif`, `!#include`, akan dianggap sebagai filter. Baca lebih lanjut di https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#pre-parsing-directives.
  - `!# this_is_comment`, jika ada spasi setelah simbol `!#` maka akan dianggap sebagi komentar.
- Baris yang dimulai dengan semua simbol yang valid untuk element hide
  - `##.`, `###`
  - `#@#.`, `#@##`
  - etc
