### PR TITLE
Consolidate third-party filters into `src/specific_block.adfl`

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -37,8 +37,6 @@ Agar mudah di-maintain, daftar filter dipecah dan dikelompokkan ke dalam beberap
  ├─ specific_block.adfl     [S] Blokir iklan.
  ├─ specific_hide.adfl      [S] Sembunyikan iklan.
  ├─ specific-hide_2.adfl    [S] ...
- ├─ thirdparty.adfl         [G] Mirip seperti filter di adservers.adfl, namun layanan utama
- │                          dari domain/IP situs tersebut bukan untuk menyediakan iklan.
  └─ whitelist.adfl          [G/S] Mengembalikan sesuatu yang seharusnya ada, namun hilang
                             karena tidak sengaja terblokir/disembunyikan.
 ```

--- a/src/general-hide.adfl
+++ b/src/general-hide.adfl
@@ -1289,7 +1289,6 @@
 ~jagoanhosting.com##[href^="https://member.jagoanhosting.com/aff.php"] > img
 ~qwords.com##[href^="https://promosi.qwords.com/"] > img
 ~adsterra.com##[href^="https://publishers.adsterra.com/referral/"] > img
-~rajabacklink.com##[href^="https://rajabacklink.com/refferal.php"] > img
 ~ajaib.co.id##[href^="https://referral.ajaib.co.id/"] > img
 ~watzap.id##[href^="https://watzap.id/ref/"] > img
 ~domainesia.com##[href^="https://www.domainesia.com/?aff="] > img

--- a/src/thirdparty.adfl
+++ b/src/thirdparty.adfl
@@ -4,12 +4,6 @@
 !# --------------------------------------------------------
 !#
 !
-||cloudhost.id/pro/privat-ads/$3p,image
-||cloudhost.id^*_ads_$3p,image
-||iklancpm.files.wordpress.com^$3p
-||rajabacklink.com^$3p
-||video-ads.lapakinfo.net/$mp4
 !
 ! AFFILIATE / REFERRAL
 ! -----------------------------------------------
-||exabytes.co.id/images/affiliate/$3p,image

--- a/src/thirdparty.adfl
+++ b/src/thirdparty.adfl
@@ -1,9 +1,0 @@
-!# Blokir iklan langsung dari sumbernya. Mirip seperti filter di adservers.adfl,
-!# namun layanan utama dari domain/IP situs tersebut bukan untuk menyediakan iklan.
-!#
-!# --------------------------------------------------------
-!#
-!
-!
-! AFFILIATE / REFERRAL
-! -----------------------------------------------

--- a/template/adblockid.template.txt
+++ b/template/adblockid.template.txt
@@ -8,7 +8,6 @@
 %include abid:src/general-block.adfl%
 %include abid:src/general-hide.adfl%
 %include abid:src/adservers.adfl%
-%include abid:src/thirdparty.adfl%
 %include abid:src/specific-block.adfl%
 %include abid:src/specific-hide.adfl%
 %include abid:src/specific-hide_2.adfl%

--- a/tests/test_adblockid.txt
+++ b/tests/test_adblockid.txt
@@ -571,7 +571,6 @@ citrahost.com
 classyfm.co.id
 click4.id
 client.okezone.com
-cloudhost.id
 cluetoday.com
 cnbcindonesia.com
 cnbtv.co.id
@@ -743,7 +742,6 @@ esportsku.com
 etindonesia.com
 ewarta.co
 ex-pose.net
-exabytes.co.id
 exey.io
 expontt.com
 exposenews.id
@@ -1058,7 +1056,6 @@ igniel.com
 ignnews.id
 ihram.co.id
 ijenindonesia.com
-iklancpm.files.wordpress.com
 iklandisini.com
 iklangratis.id
 iklangratistanpadaftar.com
@@ -2514,7 +2511,6 @@ radioonline.co.id
 radiowebindo.com
 ragam-indonesia.com
 ragamsumbar.com
-rajabacklink.com
 rajakomen.com
 rajawalinews.id
 rakcer.id
@@ -3218,7 +3214,6 @@ vcgamers.com
 venuemagz.com
 versusbeda.com
 victorynews.id
-video-ads.lapakinfo.net
 video.okezone.com
 vidio.com
 viewjabar.com


### PR DESCRIPTION
Changes
- Moved and merged filter rules previously located in `src/thirdparty.adfl` into the file `src\specific_block.adfl`.
- Removed obsolete or irrelevant filters.

The purpose is to simplify the filter file structure. The file `src/thirdparty.adfl` will be removed as part of this refactoring.